### PR TITLE
Fixed importing NavigationToolbar error

### DIFF
--- a/platereader/clsgui.py
+++ b/platereader/clsgui.py
@@ -42,7 +42,7 @@ sip.setapi('QString', 1)
 from PyQt4 import Qt
 from PyQt4 import QtCore
 from PyQt4 import QtGui
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas, NavigationToolbar2QTAgg as NavigationToolbar
+from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas, NavigationToolbar2QT as NavigationToolbar
 
 from platereader.odgui import EmptyModel, ODplateItem, ODplateModel, MyMplCanvas, DeselectableTreeView
 from platereader.odgui import getSaveFileNameDialogWithDefaultSuffix, MyProgressWidget, agpllicense

--- a/platereader/odgui.py
+++ b/platereader/odgui.py
@@ -40,7 +40,7 @@ from PyQt4 import QtGui
 
 import matplotlib.figure
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 
 from platereader.plate import Plate
 from platereader.odplot import replicateToFig, plotFullOdPlate, odPlateOverviewToAxes, replicateNderivativePlotAsPdf


### PR DESCRIPTION
More recent versions of matplotlib change how the NavigationToolbar is imported. It is fixed below.
